### PR TITLE
Create Fresh Focus SPA landing page

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,152 +1,361 @@
 <!DOCTYPE html>
 <html lang="fr">
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Trust Strip Widget</title>
-    <!-- Tailwind CSS CDN -->
-    <script src="https://cdn.tailwindcss.com"></script>
-    <!-- Google Fonts -->
-    <link href="https://fonts.googleapis.com/css2?family=Poppins:ital,wght@0,400;0,600;0,700;0,800;0,900;1,400&display=swap" rel="stylesheet">
-    <style>
-        body { font-family: 'Poppins', sans-serif; margin: 0; padding: 0; }
-
-        /* Custom Animations */
-        .animate-bounce-gentle {
-            animation: bounce-gentle 2s infinite;
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Fresh Focus — Agence digitale & design</title>
+  <meta name="description" content="Fresh Focus, agence digitale à Bruxelles/Uccle : branding, UX/UI, développement web et SEO. Découvrez nos services, l'équipe et nos informations légales."/>
+  <meta property="og:title" content="Fresh Focus — Agence digitale & design"/>
+  <meta property="og:description" content="Agence Fresh Focus : expériences digitales sur-mesure, branding, UX/UI, développement web, SEO et accompagnement stratégique."/>
+  <meta property="og:type" content="website"/>
+  <meta property="og:url" content="https://www.freshfocus.be"/>
+  <meta property="og:image" content="https://source.unsplash.com/featured/?modern,workspace"/>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=Playfair+Display:wght@600;700&display=swap" rel="stylesheet">
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script>
+    tailwind.config = {
+      theme: {
+        extend: {
+          colors: {
+            primary: '#1fb6a6',
+            dark: '#0f172a',
+            soft: '#e7f5f3',
+          },
+          fontFamily: {
+            sans: ['Inter', 'ui-sans-serif', 'system-ui'],
+            serif: ['Playfair Display', 'serif'],
+          },
         }
-        @keyframes bounce-gentle {
-            0%, 20%, 50%, 80%, 100% {transform: translateY(0);}
-            40% {transform: translateY(-5px);}
-            60% {transform: translateY(-3px);}
-        }
-    </style>
+      }
+    }
+  </script>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" integrity="sha512-GA1YcK8Z1xnqco3EQAOEjun9wioMxSsR6kgty+O+kO5OVwOB1p5MNDoAuCEi0aKBslZx2drfacrhbO3DPRT+rw==" crossorigin="anonymous" referrerpolicy="no-referrer"/>
+  <style>
+    body {font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; background: #0b1324; color: #0f172a;}
+    .glass {backdrop-filter: blur(14px);}
+    .nav-link.active {color: #1fb6a6; font-weight: 700;}
+  </style>
 </head>
-<body>
-
-    <!-- START OF INTEGRATION CODE -->
-    <!-- Wrapper with light gray background for contrast -->
-    <div class="w-full bg-[#f5f7fa] py-10 md:py-14 px-4">
-
-        <!-- Copy everything inside this section tag to integrate -->
-        <section class="w-full max-w-[1050px] mx-auto text-center font-sans">
-
-            <!-- Header Section - Transparent Background with Navy Text -->
-            <header class="mb-6 md:mb-8 bg-transparent">
-                <h2 class="text-2xl md:text-[1.8rem] font-extrabold text-[#1A2332] mb-2 leading-tight">
-                    Besoin d'un certificat PEB à Bruxelles ?
-                </h2>
-                <div class="flex flex-col items-center gap-1">
-                    <span class="text-base text-[#1A2332] font-semibold">
-                        Un tarif juste ? Des conseils d'expert ?
-                    </span>
-                    <span class="text-lg font-black text-[#339966] uppercase tracking-wider">
-                        VOUS ÊTES AU BON ENDROIT.
-                    </span>
-                </div>
-            </header>
-
-            <!-- Main Card (Navy #1A2332) -->
-            <div class="relative bg-[#1A2332] rounded-2xl p-8 md:p-10 flex flex-col-reverse md:flex-row items-center justify-between gap-10 shadow-[0_15px_35px_rgba(26,35,50,0.25)] border border-white/10 overflow-hidden md:overflow-visible">
-
-                <!-- Decorative Background Texture -->
-                <div class="absolute inset-0 pointer-events-none bg-[radial-gradient(circle_at_top_right,rgba(51,153,102,0.06),transparent_50%)] rounded-2xl"></div>
-
-                <!-- Left Content: Promise & Bio -->
-                <div class="flex-1 z-10 text-center md:text-left flex flex-col items-center md:items-start w-full">
-
-                    <!-- Top Badges -->
-                    <div class="flex flex-wrap justify-center md:justify-start gap-3 mb-4">
-                        <span class="bg-[#339966] text-white text-[0.7rem] font-bold px-3 py-1 rounded uppercase tracking-[0.5px]">
-                            OFFRE PEB RÉSIDENTIEL
-                        </span>
-                        <span class="bg-[#FFD700]/10 border border-[#FFD700]/20 text-[#FFD700] text-[0.7rem] font-bold px-3 py-1 rounded uppercase tracking-[0.5px] flex items-center gap-1.5">
-                            <!-- Lock Icon -->
-                            <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" class="shrink-0"><rect x="3" y="11" width="18" height="11" rx="2" ry="2"></rect><path d="M7 11V7a5 5 0 0 1 10 0v4"></path></svg>
-                            TARIF FIXE GARANTI
-                        </span>
-                    </div>
-
-                    <!-- Headline -->
-                    <h3 class="text-2xl md:text-[1.5rem] font-bold text-white mb-4 leading-[1.2]">
-                        Je réalise votre certificat PEB <span class="italic text-[#FFD700]">personnellement</span>.
-                    </h3>
-
-                    <!-- Quote Block -->
-                    <div class="relative mb-5 pt-3 md:pt-0 pl-0 md:pl-4 border-t-2 md:border-t-0 md:border-l-[3px] border-[#339966] w-full max-w-2xl">
-                        <p class="text-[#cbd5e1] italic leading-relaxed text-[0.95rem]">
-                            "14 ans d'expérience dans l'immobilier, probablement parmi les certificateurs les plus passionnés. <span class="text-[#F8FAFC] font-semibold not-italic block md:inline mt-1 md:mt-0">J'aime ce que je fais et je fais ce que je aime.</span>"
-                        </p>
-                    </div>
-
-                    <!-- Features List -->
-                    <div class="bg-white/10 rounded-lg p-3 md:p-4 mb-6 w-full md:w-auto text-left border border-white/5">
-                        <div class="flex items-start gap-3 mb-2 text-[#F8FAFC] text-[0.9rem]">
-                            <!-- Check Circle Icon -->
-                            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-[#339966] shrink-0 mt-0.5"><path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"></path><polyline points="22 4 12 14.01 9 11.01"></polyline></svg>
-                            <span><strong>Tout inclus :</strong> Déplacement, Conseils, Remise du rapport</span>
-                        </div>
-                        <div class="flex items-start gap-3 text-[#F8FAFC] text-[0.9rem]">
-                            <!-- Check Circle Icon -->
-                            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-[#339966] shrink-0 mt-0.5"><path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"></path><polyline points="22 4 12 14.01 9 11.01"></polyline></svg>
-                            <span>Prix affiché = Prix demandé (Zéro surprise)</span>
-                        </div>
-                    </div>
-
-                    <!-- CTA Nudge -->
-                    <a href="https://pebify.be/#prix-peb-bruxelles" class="flex items-center justify-center md:justify-start gap-2 text-[#339966] font-bold text-sm cursor-pointer animate-bounce-gentle group transition-colors hover:text-[#2da868]">
-                        <span>Calculez le prix de votre certificat PEB en quelques secondes</span>
-                        <!-- Chevron Down Icon -->
-                        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="group-hover:translate-y-1 transition-transform"><polyline points="6 9 12 15 18 9"></polyline></svg>
-                    </a>
-                </div>
-
-                <!-- Right Content: Expert Profile -->
-                <div class="shrink-0 z-10 flex flex-col items-center md:mr-6">
-
-                    <!-- Photo Container -->
-                    <div class="relative w-64 h-64 md:w-80 md:h-80 mb-3 group-profile">
-
-                        <!-- Main Image -->
-                        <img src="https://pebify.be/wp-content/uploads/2025/10/certificateur-peb-bruxelles-milad-mollaey-badge-250px.webp" alt="Milad Mollaey - Expert PEB" class="w-full h-full rounded-full border-[6px] border-white/10 object-cover bg-[#2C3E50] shadow-2xl" loading="lazy">
-
-                        <!-- Status Dot (Available) -->
-                        <div class="absolute bottom-6 left-8 w-6 h-6 bg-[#339966] border-[3px] border-[#1A2332] rounded-full shadow-[0_0_0_2px_rgba(51,153,102,0.3)] z-20" title="Disponible"></div>
-
-                        <!-- Action Buttons -->
-
-                        <!-- 1. Email (Top Right) -->
-                        <a href="mailto:info@pebify.be" class="absolute top-8 -right-2 w-14 h-14 bg-white hover:bg-[#2C3E50] hover:text-white text-[#1A2332] rounded-full flex items-center justify-center shadow-[0_4px_15px_rgba(0,0,0,0.3)] transition-all duration-300 hover:scale-110 z-30" aria-label="Envoyer un email">
-                            <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z"></path><polyline points="22,6 12,13 2,6"></polyline></svg>
-                        </a>
-
-                        <!-- 2. WhatsApp (Center Right) -->
-                        <a href="https://wa.me/32484630815" target="_blank" rel="noopener noreferrer" class="absolute top-1/2 -right-6 -translate-y-1/2 w-16 h-16 bg-white hover:bg-[#25D366] hover:text-white text-[#1A2332] rounded-full flex items-center justify-center shadow-[0_4px_15px_rgba(0,0,0,0.3)] transition-all duration-300 hover:scale-110 z-40" aria-label="Contacter par WhatsApp">
-                            <svg viewBox="0 0 24 24" fill="currentColor" class="w-6 h-6"><path d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.008-.57-.008-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347m-5.421 7.403h-.004a9.87 9.87 0 01-5.031-1.378l-.361-.214-3.741.982.998-3.648-.235-.374a9.86 9.86 0 01-1.51-5.26c.001-5.45 4.436-9.884 9.888-9.884 2.64 0 5.122 1.03 6.988 2.898a9.825 9.825 0 012.893 6.994c-.003 5.45-4.437 9.884-9.885 9.884m8.413-18.297A11.815 11.815 0 0012.05 0C5.495 0 .16 5.335.157 11.892c0 2.096.547 4.142 1.588 5.945L.057 24l6.305-1.654a11.882 11.882 0 005.683 1.448h.005c6.554 0 11.89-5.335 11.893-11.893a11.821 11.821 0 00-3.48-8.413Z"/></svg>
-                        </a>
-
-                        <!-- 3. Phone (Bottom Right) -->
-                        <a href="tel:+32484630815" class="absolute bottom-8 -right-2 w-14 h-14 bg-white hover:bg-[#339966] hover:text-white text-[#1A2332] rounded-full flex items-center justify-center shadow-[0_4px_15px_rgba(0,0,0,0.3)] transition-all duration-300 hover:scale-110 z-30" aria-label="Appeler par téléphone">
-                            <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M22 16.92v3a2 2 0 0 1-2.18 2 19.79 19.79 0 0 1-8.63-3.07 19.5 19.5 0 0 1-6-6 19.79 19.79 0 0 1-3.07-8.67A2 2 0 0 1 4.11 2h3a2 2 0 0 1 2 1.72 12.84 12.84 0 0 0 .7 2.81 2 2 0 0 1-.45 2.11L8.09 9.91a16 16 0 0 0 6 6l1.27-1.27a2 2 0 0 1 2.11-.45 12.84 12.84 0 0 0 2.81.7A2 2 0 0 1 22 16.92z"></path></svg>
-                        </a>
-
-                    </div>
-
-                    <!-- Name & Role -->
-                    <div class="text-center mt-4">
-                        <span class="block text-white font-bold text-2xl">Milad Mollaey</span>
-                        <span class="block text-[#339966] text-sm font-bold uppercase tracking-wider mt-1">
-                        Votre expert PEB dédié
-                        </span>
-                    </div>
-
-                </div>
-
+<body class="bg-gradient-to-b from-dark to-[#0b1324] text-slate-900 antialiased">
+  <header class="sticky top-0 z-50 bg-slate-900/70 glass text-white border-b border-white/10">
+    <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 flex items-center justify-between h-16">
+      <div class="flex items-center gap-3">
+        <div class="h-10 w-10 rounded-full bg-primary/20 border border-primary/40 flex items-center justify-center text-primary font-semibold">FF</div>
+        <div class="leading-tight">
+          <p class="text-sm uppercase tracking-[0.25rem] text-white/70">Fresh Focus</p>
+          <p class="text-lg font-semibold">Design + Digital Lab</p>
+        </div>
+      </div>
+      <nav class="hidden md:flex items-center gap-6 text-sm font-medium">
+        <button class="nav-link focus:outline-none" data-section="home" aria-label="Aller à l'accueil">Accueil</button>
+        <div class="relative group" aria-haspopup="true">
+          <button class="nav-link focus:outline-none" data-section="services" aria-expanded="false">Services <i class="fa-solid fa-chevron-down text-[10px] ml-1"></i></button>
+          <div class="absolute left-0 top-full mt-3 w-[650px] bg-white text-slate-900 rounded-2xl shadow-2xl p-6 hidden group-hover:block" role="menu">
+            <div class="grid grid-cols-2 gap-6">
+              <div>
+                <h3 class="text-xs uppercase tracking-widest text-slate-500 mb-2">Stratégie & Branding</h3>
+                <ul class="space-y-2 text-sm">
+                  <li class="flex items-start gap-2"><i class="fa-solid fa-wand-magic-sparkles text-primary mt-0.5"></i>Plateformes de marque</li>
+                  <li class="flex items-start gap-2"><i class="fa-solid fa-bullseye text-primary mt-0.5"></i>Positionnement & messaging</li>
+                  <li class="flex items-start gap-2"><i class="fa-solid fa-chess-knight text-primary mt-0.5"></i>Brand content & campagnes</li>
+                </ul>
+              </div>
+              <div>
+                <h3 class="text-xs uppercase tracking-widest text-slate-500 mb-2">Produit & Tech</h3>
+                <ul class="space-y-2 text-sm">
+                  <li class="flex items-start gap-2"><i class="fa-solid fa-laptop-code text-primary mt-0.5"></i>UX/UI & design systems</li>
+                  <li class="flex items-start gap-2"><i class="fa-solid fa-bolt text-primary mt-0.5"></i>Développement SPA & PWA</li>
+                  <li class="flex items-start gap-2"><i class="fa-solid fa-chart-line text-primary mt-0.5"></i>SEO technique & analytics</li>
+                </ul>
+              </div>
             </div>
-        </section>
-
+            <div class="mt-4 p-4 rounded-xl bg-soft text-slate-700 flex items-center justify-between">
+              <div>
+                <p class="text-sm font-semibold">Prêt à accélérer votre produit ?</p>
+                <p class="text-xs text-slate-600">Sprint de 10 jours : audit UX, prototype haute fidélité, roadmap claire.</p>
+              </div>
+              <button class="bg-primary text-white px-4 py-2 rounded-lg text-sm shadow-lg hover:shadow-xl transition" data-section="contact">Planifier</button>
+            </div>
+          </div>
+        </div>
+        <button class="nav-link focus:outline-none" data-section="legal" aria-label="Aller aux informations légales">Hub juridique</button>
+        <button class="nav-link focus:outline-none" data-section="contact" aria-label="Aller à la page contact">Contact & Accès</button>
+      </nav>
+      <div class="md:hidden">
+        <button id="menu-toggle" class="text-white text-2xl" aria-label="Ouvrir le menu mobile"><i class="fa-solid fa-bars"></i></button>
+      </div>
     </div>
-    <!-- END OF INTEGRATION CODE -->
+    <div id="mobile-menu" class="md:hidden hidden border-t border-white/10 bg-slate-900/90">
+      <div class="px-4 py-3 space-y-3 text-sm">
+        <button class="nav-link block w-full text-left" data-section="home">Accueil</button>
+        <button class="nav-link block w-full text-left" data-section="services">Services</button>
+        <button class="nav-link block w-full text-left" data-section="legal">Hub juridique</button>
+        <button class="nav-link block w-full text-left" data-section="contact">Contact & Accès</button>
+      </div>
+    </div>
+  </header>
 
+  <main class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+    <!-- Home Section -->
+    <section id="home" class="section py-16 text-white">
+      <div class="grid lg:grid-cols-2 gap-10 items-center">
+        <div class="space-y-6">
+          <p class="text-primary text-sm uppercase tracking-[0.3rem]">Agence digitale Bruxelles/Uccle</p>
+          <h1 class="text-4xl sm:text-5xl font-serif leading-tight">Nous créons des expériences digitales <span class="text-primary">claires</span>, <span class="text-white/80">rapides</span> et <span class="text-primary">mémorables</span>.</h1>
+          <p class="text-lg text-white/80 max-w-xl">Fresh Focus est une équipe de designers, développeurs et stratèges qui conçoivent des interfaces élégantes, des marques singulières et des produits web performants.</p>
+          <div class="flex flex-wrap gap-4">
+            <button class="bg-primary text-white px-5 py-3 rounded-xl shadow-lg hover:shadow-2xl transition" data-section="contact">Démarrer un projet</button>
+            <button class="border border-white/30 text-white px-5 py-3 rounded-xl hover:border-primary hover:text-primary transition" data-section="services">Explorer les services</button>
+          </div>
+          <div class="flex items-center gap-6 text-sm text-white/70">
+            <div class="flex items-center gap-2"><i class="fa-solid fa-leaf text-primary"></i>Design éco-conçu</div>
+            <div class="flex items-center gap-2"><i class="fa-solid fa-universal-access text-primary"></i>Accessibilité AA</div>
+            <div class="flex items-center gap-2"><i class="fa-solid fa-gauge-high text-primary"></i>Pages <2s</div>
+          </div>
+        </div>
+        <div class="relative">
+          <div class="absolute -inset-6 bg-primary/10 blur-3xl rounded-full"></div>
+          <div class="relative bg-white rounded-[28px] shadow-2xl overflow-hidden border border-white/20">
+            <img src="https://source.unsplash.com/featured/?design,team" alt="Équipe design Fresh Focus" class="h-72 w-full object-cover" loading="lazy">
+            <div class="p-6 bg-white text-slate-900 space-y-3">
+              <p class="text-xs uppercase tracking-[0.3rem] text-slate-500">Fresh Focus en chiffres</p>
+              <div class="grid grid-cols-3 gap-4 text-center">
+                <div>
+                  <p class="text-3xl font-bold text-primary">150+</p>
+                  <p class="text-xs text-slate-500">projets livrés</p>
+                </div>
+                <div>
+                  <p class="text-3xl font-bold text-primary">20%</p>
+                  <p class="text-xs text-slate-500">conversion moyenne</p>
+                </div>
+                <div>
+                  <p class="text-3xl font-bold text-primary">12</p>
+                  <p class="text-xs text-slate-500">experts seniors</p>
+                </div>
+              </div>
+              <div class="flex items-center gap-3 text-sm">
+                <img src="https://source.unsplash.com/featured/?portrait,creative" alt="Directeur de création" class="h-12 w-12 rounded-full object-cover">
+                <div>
+                  <p class="font-semibold">Léa Dahan — Directrice de création</p>
+                  <p class="text-slate-500">“Chaque pixel doit raconter l'histoire de la marque.”</p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="mt-16 grid md:grid-cols-3 gap-6">
+        <article class="bg-white/5 border border-white/10 rounded-2xl p-6 text-white/90 shadow-xl">
+          <div class="flex items-center gap-3 mb-3"><i class="fa-solid fa-seedling text-primary"></i><h3 class="font-semibold">Branding & identité</h3></div>
+          <p class="text-sm text-white/70">Naming, plateformes de marque, chartes visuelles et brand content pour une image cohérente.</p>
+        </article>
+        <article class="bg-white/5 border border-white/10 rounded-2xl p-6 text-white/90 shadow-xl">
+          <div class="flex items-center gap-3 mb-3"><i class="fa-solid fa-display text-primary"></i><h3 class="font-semibold">UX/UI & Produit</h3></div>
+          <p class="text-sm text-white/70">Recherche utilisateur, design systems, maquettes haute fidélité, prototypes interactifs.</p>
+        </article>
+        <article class="bg-white/5 border border-white/10 rounded-2xl p-6 text-white/90 shadow-xl">
+          <div class="flex items-center gap-3 mb-3"><i class="fa-solid fa-rocket text-primary"></i><h3 class="font-semibold">Tech & Performance</h3></div>
+          <p class="text-sm text-white/70">Développement SPA/PWA, optimisation SEO/UX, monitoring et analytics temps réel.</p>
+        </article>
+      </div>
+    </section>
+
+    <!-- Services Section -->
+    <section id="services" class="section hidden py-16">
+      <div class="text-center mb-12 text-white">
+        <p class="text-primary uppercase tracking-[0.3rem] text-sm">Expertises clés</p>
+        <h2 class="text-4xl font-serif">Des solutions pensées pour la clarté et la vitesse</h2>
+        <p class="text-white/70 mt-3 max-w-3xl mx-auto">Nous combinons stratégie, design et ingénierie pour lancer rapidement des expériences remarquables.</p>
+      </div>
+      <div class="grid lg:grid-cols-3 gap-6">
+        <div class="bg-white rounded-2xl p-6 shadow-xl border border-white/10">
+          <div class="flex items-center gap-3 mb-4 text-primary"><i class="fa-solid fa-bezier-curve"></i><h3 class="font-semibold text-slate-900">Branding</h3></div>
+          <p class="text-slate-600 text-sm mb-4">Plateforme de marque, identité visuelle, tone of voice, guidelines et assets prêts à déployer.</p>
+          <ul class="space-y-2 text-sm text-slate-700">
+            <li class="flex items-center gap-2"><i class="fa-regular fa-circle-check text-primary"></i>Naming & manifesto</li>
+            <li class="flex items-center gap-2"><i class="fa-regular fa-circle-check text-primary"></i>Identité & systèmes graphiques</li>
+            <li class="flex items-center gap-2"><i class="fa-regular fa-circle-check text-primary"></i>Brand content & motion boards</li>
+          </ul>
+        </div>
+        <div class="bg-white rounded-2xl p-6 shadow-xl border border-white/10">
+          <div class="flex items-center gap-3 mb-4 text-primary"><i class="fa-solid fa-swatchbook"></i><h3 class="font-semibold text-slate-900">UX/UI</h3></div>
+          <p class="text-slate-600 text-sm mb-4">Découverte, wireframes, design system modulaire, prototypes animés, tests utilisateurs.</p>
+          <ul class="space-y-2 text-sm text-slate-700">
+            <li class="flex items-center gap-2"><i class="fa-regular fa-circle-check text-primary"></i>Design sprint 10 jours</li>
+            <li class="flex items-center gap-2"><i class="fa-regular fa-circle-check text-primary"></i>Audit accessibilité AA</li>
+            <li class="flex items-center gap-2"><i class="fa-regular fa-circle-check text-primary"></i>Prototypes haute fidélité</li>
+          </ul>
+        </div>
+        <div class="bg-white rounded-2xl p-6 shadow-xl border border-white/10">
+          <div class="flex items-center gap-3 mb-4 text-primary"><i class="fa-solid fa-server"></i><h3 class="font-semibold text-slate-900">Tech & Growth</h3></div>
+          <p class="text-slate-600 text-sm mb-4">SPA/SSR, intégrations API, headless CMS, SEO technique, performance et observabilité.</p>
+          <ul class="space-y-2 text-sm text-slate-700">
+            <li class="flex items-center gap-2"><i class="fa-regular fa-circle-check text-primary"></i>Développement Vue/React-like en Vanilla optimisé</li>
+            <li class="flex items-center gap-2"><i class="fa-regular fa-circle-check text-primary"></i>Optimisation Core Web Vitals</li>
+            <li class="flex items-center gap-2"><i class="fa-regular fa-circle-check text-primary"></i>SEO & analytics temps réel</li>
+          </ul>
+        </div>
+      </div>
+      <div class="mt-12 bg-primary/10 border border-primary/30 rounded-2xl p-8 text-white">
+        <div class="flex flex-col lg:flex-row items-center justify-between gap-6">
+          <div>
+            <p class="text-sm uppercase tracking-[0.3rem] text-primary">Sprint de lancement</p>
+            <h3 class="text-2xl font-semibold">Prototype fonctionnel en 3 semaines</h3>
+            <p class="text-white/80">Ateliers, conception, développement front, intégration CMS et suivi post-lancement.</p>
+          </div>
+          <button class="bg-white text-primary px-5 py-3 rounded-xl shadow-lg hover:shadow-2xl transition" data-section="contact">Réserver un créneau</button>
+        </div>
+      </div>
+    </section>
+
+    <!-- Legal Section -->
+    <section id="legal" class="section hidden py-16 text-white">
+      <div class="text-center mb-10">
+        <p class="text-primary uppercase tracking-[0.3rem] text-sm">Informations légales & pratiques</p>
+        <h2 class="text-4xl font-serif">Hub juridique Fresh Focus</h2>
+        <p class="text-white/70 mt-3 max-w-3xl mx-auto">Retrouvez l'ensemble de nos mentions légales, politique de confidentialité, cookies et charte de déontologie.</p>
+      </div>
+      <div class="space-y-4">
+        <details class="bg-white/5 border border-white/10 rounded-xl p-5" open>
+          <summary class="cursor-pointer text-lg font-semibold flex items-center justify-between">Mentions légales <i class="fa-solid fa-chevron-down text-primary"></i></summary>
+          <div class="mt-3 text-white/80 text-sm space-y-2">
+            <p>Raison sociale : Fresh Focus — Rue Stanley 83, 1180 Bruxelles/Uccle, Belgique.</p>
+            <p>TVA : BE 0541 771 724 — Tél : +32 485 87 88 42 — Email : info@freshfocus.be</p>
+            <p>Directeur de la publication : Responsable juridique Fresh Focus.</p>
+            <p>Hébergement : [Fournisseur d'hébergement européen à confirmer par votre service juridique].</p>
+            <p>Propriété intellectuelle : sauf mention contraire, l'ensemble des contenus et visuels est la propriété de Fresh Focus. Toute reproduction est soumise à autorisation écrite préalable.</p>
+          </div>
+        </details>
+        <details class="bg-white/5 border border-white/10 rounded-xl p-5">
+          <summary class="cursor-pointer text-lg font-semibold flex items-center justify-between">Politique RGPD & Confidentialité <i class="fa-solid fa-chevron-down text-primary"></i></summary>
+          <div class="mt-3 text-white/80 text-sm space-y-2">
+            <p>[Texte légal standard à valider par votre juriste : description des données collectées, base légale, durée de conservation, droits d'accès, de rectification, d'effacement et de portabilité.]</p>
+            <p>Responsable du traitement : Fresh Focus, Rue Stanley 83, 1180 Bruxelles/Uccle, Belgique.</p>
+            <p>Contact DPO : info@freshfocus.be — réponse sous 30 jours ouvrés.</p>
+            <p>Les données sont hébergées dans l'Union Européenne et font l'objet de mesures de sécurité conformes aux bonnes pratiques.</p>
+          </div>
+        </details>
+        <details class="bg-white/5 border border-white/10 rounded-xl p-5">
+          <summary class="cursor-pointer text-lg font-semibold flex items-center justify-between">Politique des Cookies <i class="fa-solid fa-chevron-down text-primary"></i></summary>
+          <div class="mt-3 text-white/80 text-sm space-y-2">
+            <p>[Texte légal standard à valider par votre juriste : liste des cookies essentiels, analytiques et marketing, finalité, durée de vie et modalités de consentement.]</p>
+            <p>Vous pouvez gérer vos préférences de cookies à tout moment via le bandeau dédié ou en nous contactant.</p>
+          </div>
+        </details>
+        <details class="bg-white/5 border border-white/10 rounded-xl p-5">
+          <summary class="cursor-pointer text-lg font-semibold flex items-center justify-between">Charte de Déontologie <i class="fa-solid fa-chevron-down text-primary"></i></summary>
+          <div class="mt-3 text-white/80 text-sm space-y-2">
+            <p>[Texte légal standard à valider par votre juriste : principes d'intégrité, transparence, confidentialité, respect des utilisateurs et conception responsable.]</p>
+            <p>Fresh Focus s'engage à concevoir des expériences accessibles, inclusives et respectueuses de la vie privée.</p>
+          </div>
+        </details>
+      </div>
+    </section>
+
+    <!-- Contact Section -->
+    <section id="contact" class="section hidden py-16 text-white">
+      <div class="grid lg:grid-cols-2 gap-10 items-start">
+        <div class="space-y-4">
+          <p class="text-primary uppercase tracking-[0.3rem] text-sm">Contact & accès</p>
+          <h2 class="text-4xl font-serif">Parlons de votre prochain lancement</h2>
+          <p class="text-white/70">Adresse : Rue Stanley 83, 1180 Bruxelles/Uccle, Belgique.</p>
+          <div class="grid sm:grid-cols-2 gap-4 text-white/80 text-sm">
+            <div class="space-y-2 p-4 rounded-xl bg-white/5 border border-white/10">
+              <h3 class="font-semibold text-white">Coordonnées</h3>
+              <p><i class="fa-solid fa-phone text-primary mr-2"></i>+32 485 87 88 42</p>
+              <p><i class="fa-solid fa-envelope text-primary mr-2"></i>info@freshfocus.be</p>
+              <p><i class="fa-solid fa-globe text-primary mr-2"></i>www.freshfocus.be</p>
+              <p><i class="fa-solid fa-id-badge text-primary mr-2"></i>TVA : BE 0541 771 724</p>
+            </div>
+            <div class="space-y-2 p-4 rounded-xl bg-white/5 border border-white/10">
+              <h3 class="font-semibold text-white">Horaires</h3>
+              <p>Lun - Sam : 10h - 18h</p>
+              <p>Dim : Fermé</p>
+              <p class="text-primary font-medium">Réponse en moins de 24h</p>
+            </div>
+          </div>
+          <div class="flex flex-wrap gap-3 text-sm">
+            <a href="tel:+32485878842" class="bg-primary text-white px-4 py-3 rounded-xl shadow-lg hover:shadow-2xl transition flex items-center gap-2"><i class="fa-solid fa-phone"></i>Appeler</a>
+            <a href="mailto:info@freshfocus.be" class="border border-white/30 text-white px-4 py-3 rounded-xl hover:border-primary hover:text-primary transition flex items-center gap-2"><i class="fa-solid fa-paper-plane"></i>Écrire</a>
+          </div>
+        </div>
+        <div class="bg-white rounded-2xl shadow-2xl overflow-hidden border border-white/20">
+          <div class="h-80">
+            <iframe title="Carte Fresh Focus" src="https://www.google.com/maps?q=Rue%20Stanley%2083%2C%20Bruxelles&output=embed" class="w-full h-full" loading="lazy"></iframe>
+          </div>
+          <div class="p-5 text-slate-800 bg-white">
+            <p class="text-sm text-slate-600">Accès : Tram 94 « Bascule », Bus 38/60 « Cavell ». Parking public à 200m.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer class="mt-20 border-t border-white/10 bg-slate-900/80 text-white">
+    <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-10 flex flex-col lg:flex-row justify-between gap-6">
+      <div>
+        <p class="text-sm uppercase tracking-[0.3rem] text-white/60">Fresh Focus</p>
+        <p class="text-lg font-semibold">Rue Stanley 83, 1180 Bruxelles/Uccle</p>
+        <p class="text-white/70">+32 485 87 88 42 • info@freshfocus.be</p>
+      </div>
+      <div class="flex items-center gap-4">
+        <a href="https://www.linkedin.com" class="text-white/70 hover:text-primary" aria-label="LinkedIn"><i class="fa-brands fa-linkedin text-xl"></i></a>
+        <a href="https://www.behance.net" class="text-white/70 hover:text-primary" aria-label="Behance"><i class="fa-brands fa-behance text-xl"></i></a>
+        <a href="https://www.instagram.com" class="text-white/70 hover:text-primary" aria-label="Instagram"><i class="fa-brands fa-instagram text-xl"></i></a>
+      </div>
+      <div class="text-white/60 text-sm">Lun-Sam : 10h-18h • Dim : fermé</div>
+    </div>
+  </footer>
+
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "LocalBusiness",
+    "name": "Fresh Focus",
+    "image": "https://source.unsplash.com/featured/?agency",
+    "url": "https://www.freshfocus.be",
+    "telephone": "+32 485 87 88 42",
+    "address": {
+      "@type": "PostalAddress",
+      "streetAddress": "Rue Stanley 83",
+      "addressLocality": "Bruxelles/Uccle",
+      "postalCode": "1180",
+      "addressCountry": "BE"
+    },
+    "openingHoursSpecification": [
+      {"@type": "OpeningHoursSpecification", "dayOfWeek": ["Monday","Tuesday","Wednesday","Thursday","Friday","Saturday"], "opens": "10:00", "closes": "18:00"},
+      {"@type": "OpeningHoursSpecification", "dayOfWeek": "Sunday", "opens": "00:00", "closes": "00:00", "description": "Fermé"}
+    ],
+    "sameAs": ["https://www.linkedin.com", "https://www.behance.net", "https://www.instagram.com"]
+  }
+  </script>
+
+  <script>
+    const sections = document.querySelectorAll('.section');
+    const navLinks = document.querySelectorAll('.nav-link');
+    const mobileMenu = document.getElementById('mobile-menu');
+    const menuToggle = document.getElementById('menu-toggle');
+
+    function showSection(id) {
+      sections.forEach(section => section.classList.toggle('hidden', section.id !== id));
+      navLinks.forEach(link => link.classList.toggle('active', link.dataset.section === id));
+      if (!mobileMenu.classList.contains('hidden')) mobileMenu.classList.add('hidden');
+      window.scrollTo({ top: 0, behavior: 'smooth' });
+    }
+
+    navLinks.forEach(link => {
+      link.addEventListener('click', () => showSection(link.dataset.section));
+    });
+
+    menuToggle?.addEventListener('click', () => {
+      mobileMenu.classList.toggle('hidden');
+    });
+
+    // Default section
+    showSection('home');
+  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- rebuild the index into a single-page Tailwind layout with sticky header, mega menu, and mobile navigation
- add hero, services, legal hub, and contact sections containing the required data and placeholders
- include SEO meta tags, Open Graph data, and JSON-LD schema plus navigation logic for smooth SPA-style section switching

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693df443612c832896ef92efcdf5b08b)